### PR TITLE
Fix missing Ubuntu image (Vagrantfile) and wrong default namespace (README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ status:
 
 ```shell
 $ vagrant ssh
-vagrant@argocd-nutshell:~$ kubectl get pods
+vagrant@argocd-nutshell:~$ kubectl get pods -n argocd
 NAME                                  READY   STATUS    RESTARTS   AGE
 argocd-redis-6fb68d9df5-sx7xh         1/1     Running   0          4m30s
 argocd-dex-server-748c65b578-kqlpp    1/1     Running   0          4m30s

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -28,7 +28,7 @@ EOF
 SCRIPT
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/groovy64"
+  config.vm.box = "ubuntu/xenial64"
   config.vm.hostname = "argocd-nutshell"
   config.vm.define "argocd-nutshell"
 


### PR DESCRIPTION
This PR introduces two changes to the current state of the repo:

1) Changing image "ubuntu/groovy64" by "ubuntu/xenial64" in Vagrantfile.
It seems like the image [https://app.vagrantup.com/ubuntu/boxes/groovy64]("ubuntu/groovy64") is not available anymore in Vagrant Cloud, so I've changed it to "ubuntu/xenial64", the only one that I could make work (at first I tried with "ubuntu/focal64", but I get an error when trying to mount the `/vagrant` filesystem).

2) Adding `-n argocd` in README.md.
To check if the pods are running after executing `vagrant ssh`, we need to specify the namespace where they are actually running (the default namespace is empty):
`kubectl get pods -n argocd`
